### PR TITLE
NOT_DRAW_SINGLE_POINTS throws error

### DIFF
--- a/Assets/MarkerLessARExample/CapturePattern.cs
+++ b/Assets/MarkerLessARExample/CapturePattern.cs
@@ -162,7 +162,8 @@ namespace MarkerLessARExample
 
                 detector.detect (rgbaMat, keypoints);
 //                Debug.Log ("keypoints.ToString() " + keypoints.ToString());
-                Features2d.drawKeypoints (rgbMat, keypoints, rgbaMat, Scalar.all (-1), Features2d.NOT_DRAW_SINGLE_POINTS);
+                //Features2d.drawKeypoints (rgbMat, keypoints, rgbaMat, Scalar.all (-1), Features2d.NOT_DRAW_SINGLE_POINTS);
+                Features2d.drawKeypoints (rgbMat, keypoints, rgbaMat, Scalar.all (-1), 2);
 
                 Imgproc.rectangle (rgbaMat, patternRect.tl (), patternRect.br (), new Scalar (255, 0, 0, 255), 5);
 


### PR DESCRIPTION
Assets/MarkerLessARExample/MarkerLessAR/DebugHelpers.cs(66,28): error CS0117: OpenCVForUnity.Features2d' does not contain a definition for NOT_DRAW_SINGLE_POINTS'

Not sure what the best solve is for this, but NOT_DRAW_SINGLE_POINTS resolves to 2, ([reference](https://enoxsoftware.github.io/OpenCVForUnity/doc/html/class_open_c_v_for_unity_1_1_features2d.html#a49e2dcbbf32d193f057248b12c3e2412)), so I've substituted that and it seems to work fine for me locally.